### PR TITLE
Fix: In the list of functions, circb was misspelled and elli & ellib were missing.

### DIFF
--- a/src/lualexer.py
+++ b/src/lualexer.py
@@ -380,7 +380,7 @@ class LuaLexer(object):
             set_id_prop(k, 'reserved')
             set_id_prop(k, 'keyword')
 
-        funcs = ('btn,btnp,circ,cirb,clip,cls,exit,fget,font,fset,'
+        funcs = ('btn,btnp,circ,circb,elli,ellib,clip,cls,exit,fget,font,fset,'
                  'key,keyp,line,load,'
                  'map,memcpy,mget,mouse,mset,music,OVR,peek,peek4,'
                  'pix,pmem,poke,poke4,print,rect,rectb,reset,'


### PR DESCRIPTION
This resulted pactic replacing e.g. circb and elllib in an array {cirb,ellib} with weird letters. With the functions in the list, they now work properly.